### PR TITLE
fix: harden validator config handling

### DIFF
--- a/github_paths.py
+++ b/github_paths.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Optional
+
+
+def _validate_component(value: Optional[str], label: str) -> str:
+    if value is None:
+        raise ValueError(f"Missing GitHub {label}. Please set the corresponding GITHUB_REPO_* variable.")
+
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"GitHub {label} cannot be empty.")
+    if normalized in {".", ".."}:
+        raise ValueError(f"GitHub {label} cannot be '{normalized}'.")
+    if "/" in normalized or "\\" in normalized:
+        raise ValueError(f"GitHub {label} must not contain path separators.")
+
+    return normalized
+
+
+def normalize_github_repo_path(repo_path: Optional[str]) -> str:
+    if repo_path is None:
+        return ""
+
+    normalized = repo_path.strip()
+    if not normalized:
+        return ""
+    if normalized.startswith(("/", "\\")):
+        raise ValueError("GitHub repo path must be relative and must not start with a slash.")
+
+    segments = normalized.split("/")
+    if any(not segment or segment in {".", ".."} or "\\" in segment for segment in segments):
+        raise ValueError("GitHub repo path must not contain empty, '.', '..', or backslash segments.")
+
+    return "/".join(segments)
+
+
+def build_github_path(
+    owner: Optional[str], repo: Optional[str], branch: Optional[str], repo_path: Optional[str]
+) -> str:
+    github_path = "/".join(
+        [
+            _validate_component(owner, "owner"),
+            _validate_component(repo, "repository name"),
+            _validate_component(branch, "branch"),
+        ]
+    )
+    normalized_repo_path = normalize_github_repo_path(repo_path)
+    if normalized_repo_path:
+        github_path = f"{github_path}/{normalized_repo_path}"
+
+    if len(github_path) > 100:
+        raise ValueError("GitHub path is too long. Please shorten it to 100 characters or less.")
+
+    return github_path

--- a/neurons/downloads.py
+++ b/neurons/downloads.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+import subprocess
+
+
+def download_model_file(destination: str, url: str, timeout: int = 300) -> None:
+    directory = os.path.dirname(destination)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+    try:
+        subprocess.run(
+            ["wget", "-O", destination, url],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("wget is required to download model weights.") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"Timed out downloading model weights from {url}.") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or exc.stdout or "").strip()
+        error_message = stderr or f"exit code {exc.returncode}"
+        raise RuntimeError(f"Failed to download model weights from {url}: {error_message}") from exc

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -26,6 +26,8 @@ BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(BASE_DIR)
 
 from config.config_loader import load_config
+from github_paths import build_github_path
+from neurons.downloads import download_model_file
 from utils import (
     get_sequence_from_protein_code,
     upload_file_to_github,
@@ -85,26 +87,13 @@ def load_github_path() -> str:
     
     Returns:
         str: The fully qualified GitHub path (owner/repo/branch/path).
-    Raises:
-        ValueError: If the final path exceeds 100 characters.
     """
     github_repo_name = os.environ.get('GITHUB_REPO_NAME')  # e.g., "nova"
     github_repo_branch = os.environ.get('GITHUB_REPO_BRANCH')  # e.g., "main"
     github_repo_owner = os.environ.get('GITHUB_REPO_OWNER')  # e.g., "metanova-labs"
     github_repo_path = os.environ.get('GITHUB_REPO_PATH')  # e.g., "data/results" or ""
 
-    if github_repo_name is None or github_repo_branch is None or github_repo_owner is None:
-        raise ValueError("Missing one or more GitHub environment variables (GITHUB_REPO_*)")
-
-    if github_repo_path == "":
-        github_path = f"{github_repo_owner}/{github_repo_name}/{github_repo_branch}"
-    else:
-        github_path = f"{github_repo_owner}/{github_repo_name}/{github_repo_branch}/{github_repo_path}"
-
-    if len(github_path) > 100:
-        raise ValueError("GitHub path is too long. Please shorten it to 100 characters or less.")
-
-    return github_path
+    return build_github_path(github_repo_owner, github_repo_name, github_repo_branch, github_repo_path)
 
 
 # ----------------------------------------------------------------------------
@@ -499,10 +488,11 @@ async def run_miner(config: argparse.Namespace) -> None:
                 state['psichic_models'][antitarget_protein] = model
                 bt.logging.info(f"Initialized model for antitarget: {antitarget_protein}")
         except Exception as e:
+            bt.logging.warning(f"Initial model setup failed, retrying after redownloading weights: {e}")
             try:
-                os.system(
-                    f"wget -O {os.path.join(BASE_DIR, 'PSICHIC/trained_weights/TREAT1/model.pt')} "
-                    f"https://huggingface.co/Metanova/TREAT-1/resolve/main/model.pt"
+                download_model_file(
+                    os.path.join(BASE_DIR, 'PSICHIC/trained_weights/TREAT1/model.pt'),
+                    "https://huggingface.co/Metanova/TREAT-1/resolve/main/model.pt",
                 )
                 # Retry initialization after download
                 for target_protein in state['current_challenge_targets']:
@@ -587,10 +577,11 @@ async def run_miner(config: argparse.Namespace) -> None:
                             state['psichic_models'][antitarget_protein] = model
                             bt.logging.info(f"Initialized model for antitarget: {antitarget_protein}")
                 except Exception as e:
+                    bt.logging.warning(f"Model refresh failed, retrying after redownloading weights: {e}")
                     try:
-                        os.system(
-                            f"wget -O {os.path.join(BASE_DIR, 'PSICHIC/trained_weights/TREAT1/model.pt')} "
-                            f"https://huggingface.co/Metanova/TREAT-1/resolve/main/model.pt"
+                        download_model_file(
+                            os.path.join(BASE_DIR, 'PSICHIC/trained_weights/TREAT1/model.pt'),
+                            "https://huggingface.co/Metanova/TREAT-1/resolve/main/model.pt",
                         )
                         # Retry initialization after download
                         for target_protein in state['current_challenge_targets']:

--- a/neurons/validator/commitments.py
+++ b/neurons/validator/commitments.py
@@ -7,7 +7,7 @@ import hashlib
 import requests
 from ast import literal_eval
 from types import SimpleNamespace
-from typing import cast, Optional
+from typing import Any, Mapping, Optional, cast
 
 import bittensor as bt
 from bittensor.core.chain_data.utils import decode_metadata
@@ -53,7 +53,7 @@ async def get_commitments(subtensor, metagraph, block_hash: str, netuid: int, mi
     return result
 
 
-def tuple_safe_eval(input_str: str) -> tuple:
+def tuple_safe_eval(input_str: str) -> Optional[tuple[int, bytes]]:
     # Limit input size to prevent overly large inputs.
     if len(input_str) > MAX_RESPONSE_SIZE:
         bt.logging.error("Input exceeds allowed size")
@@ -84,7 +84,12 @@ def tuple_safe_eval(input_str: str) -> tuple:
     return result
 
 
-def decrypt_submissions(current_commitments: dict, github_headers: dict, btd, config: dict) -> tuple[dict, dict]:
+def decrypt_submissions(
+    current_commitments: dict[str, SimpleNamespace],
+    github_headers: dict[str, str],
+    btd: Any,
+    config: Mapping[str, int],
+) -> tuple[dict[int, list[str]], dict[int, str]]:
     """Fetch GitHub submissions and file-specific commit timestamps, then decrypt"""
 
     file_paths = [commit.data for commit in current_commitments.values() if '/' in commit.data]
@@ -156,7 +161,17 @@ def decrypt_submissions(current_commitments: dict, github_headers: dict, btd, co
     bt.logging.info(f"GitHub: {len(file_paths)} paths → {len(decrypted_submissions)} decrypted")
     return decrypted_submissions, push_timestamps
 
-async def gather_and_decrypt_commitments(subtensor, metagraph, netuid, start_block, current_block, no_submission_blocks, github_headers, btd):
+async def gather_and_decrypt_commitments(
+    subtensor: Any,
+    metagraph: Any,
+    netuid: int,
+    start_block: int,
+    current_block: int,
+    no_submission_blocks: int,
+    github_headers: dict[str, str],
+    btd: Any,
+    num_molecules: int,
+) -> tuple[dict[int, dict[str, Any]], dict[str, SimpleNamespace], dict[int, list[str]], dict[int, str]]:
     # Get commitments
     current_block_hash = await subtensor.determine_block_hash(current_block)
     current_commitments = await get_commitments(
@@ -171,7 +186,7 @@ async def gather_and_decrypt_commitments(subtensor, metagraph, netuid, start_blo
 
     # Decrypt submissions
     decrypted_submissions, push_timestamps = decrypt_submissions(
-        current_commitments, github_headers, btd, {"num_molecules": 1}  # Default config
+        current_commitments, github_headers, btd, {"num_molecules": num_molecules}
     )
 
     # Prepare structured data

--- a/neurons/validator/ranking.py
+++ b/neurons/validator/ranking.py
@@ -4,19 +4,19 @@ Final scoring and winner determination functionality for the validator
 
 import math
 import datetime
-from typing import Optional
+from typing import Any, Optional
 
 import bittensor as bt
 from utils import calculate_dynamic_entropy
 
 
 def calculate_final_scores(
-    score_dict: dict[int, dict[str, list[list[float]]]],
+    score_dict: dict[int, dict[str, Any]],
     valid_molecules_by_uid: dict[int, dict[str, list[str]]],
     molecule_name_counts: dict[str, int],
     config: dict,
     current_epoch: int
-) -> dict[int, dict[str, list[list[float]]]]:
+) -> dict[int, dict[str, Any]]:
     """
     Calculates final scores per molecule for each UID, considering target and antitarget scores.
     Applies entropy bonus and tie-breaking by earliest submission block.
@@ -66,11 +66,19 @@ def calculate_final_scores(
                 combined_molecule_scores.append(-math.inf)
                 molecule_scores_after_repetition.append(-math.inf)
                 continue
+            if not target_scores_for_mol:
+                combined_molecule_scores.append(-math.inf)
+                molecule_scores_after_repetition.append(-math.inf)
+                continue
             avg_target = sum(target_scores_for_mol) / len(target_scores_for_mol)
 
             # Calculate average antitarget score for this molecule
             antitarget_scores_for_mol = [antitarget_list[mol_idx] for antitarget_list in antitargets]
             if any(score == -math.inf for score in antitarget_scores_for_mol):
+                combined_molecule_scores.append(-math.inf)
+                molecule_scores_after_repetition.append(-math.inf)
+                continue
+            if not antitarget_scores_for_mol:
                 combined_molecule_scores.append(-math.inf)
                 molecule_scores_after_repetition.append(-math.inf)
                 continue
@@ -141,7 +149,13 @@ def calculate_final_scores(
     return score_dict
 
 
-def determine_winner(score_dict: dict[int, dict[str, list[list[float]]]], mode: str = "max", model_name: str = "boltz", log_message: bool = True) -> Optional[int]:
+def determine_winner(
+    score_dict: dict[int, dict[str, Any]],
+    mode: str = "max",
+    model_name: str = "boltz",
+    log_message: bool = True,
+    epoch_length: int = 361,
+) -> Optional[int]:
     """
     Determines the winning UID based on final score.
     In case of ties, earliest submission time is used as the tiebreaker.
@@ -162,7 +176,7 @@ def determine_winner(score_dict: dict[int, dict[str, list[list[float]]]], mode: 
 
     best_uids = []
 
-    def parse_timestamp(uid):
+    def parse_timestamp(uid: int) -> datetime.datetime:
         ts = score_dict[uid].get('push_time', '')
         try:
             return datetime.datetime.fromisoformat(ts)
@@ -170,7 +184,7 @@ def determine_winner(score_dict: dict[int, dict[str, list[list[float]]]], mode: 
             bt.logging.warning(f"Failed to parse timestamp '{ts}' for UID={uid}: {e}")
             return datetime.datetime.max.replace(tzinfo=datetime.timezone.utc)
 
-    def tie_breaker(tied_uids: list[int], best_score: float, model_name: str, print_message: bool = True):
+    def tie_breaker(tied_uids: list[int], best_score: float, model_name: str, print_message: bool = True) -> int:
         # Sort by block number first, then push time, then uid to ensure deterministic result
         winner = sorted(tied_uids, key=lambda uid: (
             score_dict[uid].get('block_submitted', float('inf')), 
@@ -179,7 +193,7 @@ def determine_winner(score_dict: dict[int, dict[str, list[list[float]]]], mode: 
         ))[0]
         
         winner_block = score_dict[winner].get('block_submitted')
-        current_epoch = winner_block // 361 if winner_block else None
+        current_epoch = winner_block // epoch_length if winner_block is not None else None
         push_time = score_dict[winner].get('push_time', '')
         
         tiebreaker_message = f"Epoch {current_epoch} tiebreaker {model_name} winner: UID={winner}, score={best_score}, block={winner_block}"
@@ -230,7 +244,7 @@ def determine_winner(score_dict: dict[int, dict[str, list[list[float]]]], mode: 
     if best_uids:
         if len(best_uids) == 1:
             winner_block = score_dict[best_uids[0]].get('block_submitted')
-            current_epoch = winner_block // 361 if winner_block else None
+            current_epoch = winner_block // epoch_length if winner_block is not None else None
             winner = best_uids[0]
             if log_message:
                 bt.logging.info(f"Epoch {current_epoch} {model_name} winner: UID={winner}, score={best_score}, block={winner_block}")

--- a/neurons/validator/scoring.py
+++ b/neurons/validator/scoring.py
@@ -3,9 +3,11 @@ PSICHIC-based molecular scoring functionality for the validator
 """
 
 import math
-import os
+from typing import Any, Optional
+
 import bittensor as bt
 
+from neurons.downloads import download_model_file
 from utils import get_sequence_from_protein_code
 
 # Global variable to store PSICHIC instance - will be set by validator.py
@@ -13,13 +15,31 @@ psichic = None
 BASE_DIR = None
 
 
+def _apply_failed_initialization_scores(
+    score_dict: dict[int, dict[str, Any]],
+    valid_molecules_by_uid: dict[int, dict[str, list[str]]],
+    uid_to_data: Optional[dict[int, dict[str, Any]]],
+    score_key: str,
+    col_idx: int,
+) -> list[int]:
+    affected_uids = []
+    for uid in score_dict:
+        num_molecules = len(valid_molecules_by_uid.get(uid, {}).get('smiles', []))
+        if num_molecules == 0 and uid_to_data:
+            num_molecules = len(uid_to_data.get(uid, {}).get("molecules", []))
+        score_dict[uid][score_key][col_idx] = [-math.inf] * num_molecules
+        affected_uids.append(uid)
+
+    return affected_uids
+
+
 def score_all_proteins_psichic(
     target_proteins: list[str],
     antitarget_proteins: list[str],
-    score_dict: dict[int, dict[str, list[list[float]]]],
+    score_dict: dict[int, dict[str, Any]],
     valid_molecules_by_uid: dict[int, dict[str, list[str]]],
-    uid_to_data: dict = None,
-    batch_size: int = 32
+    uid_to_data: Optional[dict[int, dict[str, Any]]] = None,
+    batch_size: int = 32,
 ) -> None:
     """
     Score all molecules against all proteins using efficient batching.
@@ -55,19 +75,28 @@ def score_all_proteins_psichic(
             psichic.run_challenge_start(protein_sequence)
             bt.logging.info('Model initialized successfully.')
         except Exception as e:
+            bt.logging.warning(f"Model initialization failed for protein {protein}, retrying after re-download: {e}")
             try:
                 if BASE_DIR:
-                    os.system(f"wget -O {os.path.join(BASE_DIR, 'PSICHIC/trained_weights/TREAT1/model.pt')} https://huggingface.co/Metanova/TREAT-1/resolve/main/model.pt")
+                    download_model_file(
+                        f"{BASE_DIR}/PSICHIC/trained_weights/TREAT1/model.pt",
+                        "https://huggingface.co/Metanova/TREAT-1/resolve/main/model.pt",
+                    )
                 psichic.run_challenge_start(protein_sequence)
                 bt.logging.info('Model initialized successfully.')
-            except Exception as e:
-                bt.logging.error(f'Error initializing model: {e}')
-                # Set all scores to -inf for this protein
-                for uid in score_dict:
-                    num_molecules = len(valid_molecules_by_uid.get(uid, {}).get('smiles', []))
-                    if num_molecules == 0 and uid_to_data:
-                        num_molecules = len(uid_to_data.get(uid, {}).get("molecules", []))
-                    score_dict[uid]["target_scores" if is_target else "antitarget_scores"][col_idx] = [-math.inf] * num_molecules
+            except Exception as retry_error:
+                score_key = "target_scores" if is_target else "antitarget_scores"
+                affected_uids = _apply_failed_initialization_scores(
+                    score_dict=score_dict,
+                    valid_molecules_by_uid=valid_molecules_by_uid,
+                    uid_to_data=uid_to_data,
+                    score_key=score_key,
+                    col_idx=col_idx,
+                )
+                bt.logging.error(
+                    f"Error initializing model for protein {protein}: {retry_error}. "
+                    f"Setting -inf for UIDs {affected_uids}."
+                )
                 continue
         
         # Collect all unique molecules across all UIDs
@@ -149,5 +178,4 @@ def score_molecule_individually(smiles: str) -> float:
     except Exception as e:
         bt.logging.error(f"Error scoring molecule {smiles}: {e}")
         return -math.inf
-
 

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -79,7 +79,15 @@ async def process_epoch(config, current_block, metagraph, subtensor, wallet):
 
         # Gather and decrypt commitments
         uid_to_data, current_commitments, decrypted_submissions, push_timestamps = await gather_and_decrypt_commitments(
-            subtensor, metagraph, config.netuid, start_block, current_block, config.no_submission_blocks, GITHUB_HEADERS, btd
+            subtensor,
+            metagraph,
+            config.netuid,
+            start_block,
+            current_block,
+            config.no_submission_blocks,
+            GITHUB_HEADERS,
+            btd,
+            config.num_molecules,
         )
 
         if not uid_to_data:
@@ -169,8 +177,20 @@ async def process_epoch(config, current_block, metagraph, subtensor, wallet):
             bt.logging.debug(f"boltz_score_averages: {boltz_score_averages}")
 
         # Determine winner for each model
-        winner_psichic = determine_winner(score_dict, mode=config['psichic_mode'], model_name="psichic", log_message=False)
-        winner_boltz = determine_winner(score_dict, mode=config['boltz_mode'], model_name="boltz", log_message=True)
+        winner_psichic = determine_winner(
+            score_dict,
+            mode=config['psichic_mode'],
+            model_name="psichic",
+            log_message=False,
+            epoch_length=config.epoch_length,
+        )
+        winner_boltz = determine_winner(
+            score_dict,
+            mode=config['boltz_mode'],
+            model_name="boltz",
+            log_message=True,
+            epoch_length=config.epoch_length,
+        )
 
         # Yield so ws heartbeats can run before the next RPC
         await asyncio.sleep(0)

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,0 +1,34 @@
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from neurons.downloads import download_model_file
+
+
+class DownloadModelFileTests(unittest.TestCase):
+    @patch("neurons.downloads.subprocess.run")
+    def test_download_model_file_uses_checked_wget(self, mocked_run) -> None:
+        download_model_file("/tmp/model.pt", "https://example.com/model.pt", timeout=12)
+
+        mocked_run.assert_called_once_with(
+            ["wget", "-O", "/tmp/model.pt", "https://example.com/model.pt"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=12,
+        )
+
+    @patch("neurons.downloads.subprocess.run")
+    def test_download_model_file_surfaces_process_errors(self, mocked_run) -> None:
+        mocked_run.side_effect = subprocess.CalledProcessError(
+            4,
+            ["wget"],
+            stderr="network failed",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "network failed"):
+            download_model_file("/tmp/model.pt", "https://example.com/model.pt")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_github_paths.py
+++ b/tests/test_github_paths.py
@@ -1,0 +1,27 @@
+import unittest
+
+from github_paths import build_github_path, normalize_github_repo_path
+
+
+class GitHubPathTests(unittest.TestCase):
+    def test_build_github_path_accepts_nested_relative_paths(self) -> None:
+        self.assertEqual(
+            build_github_path("metanova-labs", "nova", "main", "data/results"),
+            "metanova-labs/nova/main/data/results",
+        )
+
+    def test_build_github_path_rejects_invalid_components(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not contain path separators"):
+            build_github_path("metanova/labs", "nova", "main", "")
+
+    def test_normalize_github_repo_path_rejects_path_traversal(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must not contain empty, '.', '..'"):
+            normalize_github_repo_path("../results")
+
+    def test_normalize_github_repo_path_rejects_leading_slash(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must be relative"):
+            normalize_github_repo_path("/data/results")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class _FakeLogger:
+    def __init__(self) -> None:
+        self.info_messages = []
+        self.warning_messages = []
+
+    def info(self, message, *args, **kwargs) -> None:
+        self.info_messages.append(message)
+
+    def warning(self, message, *args, **kwargs) -> None:
+        self.warning_messages.append(message)
+
+    def error(self, message, *args, **kwargs) -> None:
+        pass
+
+
+class RankingTests(unittest.TestCase):
+    def _load_ranking_module(self):
+        logger = _FakeLogger()
+        fake_bt = types.SimpleNamespace(logging=logger)
+        fake_utils = types.SimpleNamespace(calculate_dynamic_entropy=lambda **kwargs: 0.0)
+
+        sys.modules.pop("neurons.validator.ranking", None)
+        with patch.dict(sys.modules, {"bittensor": fake_bt, "utils": fake_utils}):
+            module = importlib.import_module("neurons.validator.ranking")
+
+        return module, logger
+
+    def test_determine_winner_uses_supplied_epoch_length_in_logs(self) -> None:
+        ranking, logger = self._load_ranking_module()
+
+        winner = ranking.determine_winner(
+            {
+                1: {"boltz_score": 1.5, "block_submitted": 130},
+                2: {"boltz_score": 3.0, "block_submitted": 725},
+            },
+            model_name="boltz",
+            epoch_length=100,
+        )
+
+        self.assertEqual(winner, 2)
+        self.assertIn("Epoch 7 boltz winner: UID=2, score=3.0, block=725", logger.info_messages)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/github.py
+++ b/utils/github.py
@@ -2,6 +2,7 @@ import os
 import requests
 import bittensor as bt
 from dotenv import load_dotenv
+from github_paths import build_github_path, normalize_github_repo_path
 
 load_dotenv(override=True)
 
@@ -17,7 +18,9 @@ def upload_file_to_github(filename: str, encoded_content: str):
     if not github_repo_name or not github_repo_branch or not github_token or not github_repo_owner:
         raise ValueError("Github environment variables not set. Please set them in your .env file.")
 
-    target_file_path = os.path.join(github_repo_path, f'{filename}.txt')
+    build_github_path(github_repo_owner, github_repo_name, github_repo_branch, github_repo_path)
+    normalized_repo_path = normalize_github_repo_path(github_repo_path)
+    target_file_path = f"{normalized_repo_path}/{filename}.txt" if normalized_repo_path else f"{filename}.txt"
     url = f"https://api.github.com/repos/{github_repo_owner}/{github_repo_name}/contents/{target_file_path}"
     headers = {
         "Authorization": f"Bearer {github_token}",


### PR DESCRIPTION
Closes #53

## Summary
- validate GitHub owner/repo/branch/path inputs before building upload paths and reuse the same normalization in the upload helper
- replace validator/miner weight re-download `os.system()` calls with checked `wget` subprocess execution and clearer retry logging
- pass the configured molecule count and epoch length through validator scoring so commitments and winner logs follow runtime config rather than hardcoded defaults
- add stdlib-only regression tests for GitHub path validation, download error handling, and winner epoch logging

## Validation
- `python3 -m unittest discover -s /Users/odeili/Projects/nova/tests -q`
- `python3 -m compileall /Users/odeili/Projects/nova/github_paths.py /Users/odeili/Projects/nova/neurons/downloads.py /Users/odeili/Projects/nova/neurons/miner.py /Users/odeili/Projects/nova/neurons/validator /Users/odeili/Projects/nova/utils/github.py`

## Notes
- the existing modified binary at `PSICHIC/trained_weights/PDBv2020_PSICHIC/model.pt` was already dirty locally and is intentionally not part of this PR
