### PR TITLE
Fix: Minimal Spawn Isolation for Deterministic Boltz2 Scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ venv/
 *.log
 *.log.*
 combinatorial_db/molecules.sqlite
+
+# Temporary runtime directories
+external_tools/boltz/boltz_tmp_files/
+external_tools/boltzgen/boltzgen_tmp_files/
+external_tools/igblast/
+

--- a/external_tools/boltz/boltz_wrapper.py
+++ b/external_tools/boltz/boltz_wrapper.py
@@ -9,6 +9,8 @@ import hashlib
 import math
 import shutil
 import glob
+import tempfile
+import multiprocessing as mp
 
 os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':4096:8'
 os.environ["OMP_NUM_THREADS"] = "1"
@@ -29,6 +31,91 @@ from utils.molecules import compute_maccs_entropy, is_boltz_safe_smiles, get_hea
 def _get_record_id(rec_id, base_seed):
     h = hashlib.sha256(str(rec_id).encode()).digest()
     return (int.from_bytes(h[:8], "little") ^ base_seed) % (2**31 - 1)
+
+
+# Timeout for each spawn-process prediction (seconds)
+_SPAWN_PREDICT_TIMEOUT = 3600
+
+
+def _spawn_predict_worker(
+    smiles: str,
+    target: str,
+    protein_sequence: str,
+    mol_idx: int,
+    base_seed: int,
+    config: dict,
+    result_queue: mp.Queue,
+    gpu_id: int,
+) -> None:
+    """Worker: predict a single molecule in complete isolation.
+
+    Must be a module-level function for spawn compatibility.
+    """
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+    try:
+        tmp_dir = tempfile.mkdtemp(prefix=f"boltz_iso_{mol_idx}_")
+        input_dir = os.path.join(tmp_dir, "inputs")
+        output_dir = os.path.join(tmp_dir, "outputs")
+        os.makedirs(input_dir, exist_ok=True)
+        os.makedirs(output_dir, exist_ok=True)
+
+        yaml_content = f"""version: 1
+sequences:
+  - protein:
+      id: A
+      sequence: {protein_sequence}
+      msa: {os.path.join(NOVA_DIR, 'data', 'msa_files', target + '.a3m')}
+  - ligand:
+      id: B
+      smiles: {smiles}
+properties:
+  - affinity:
+      binder: B
+"""
+        yaml_path = os.path.join(input_dir, f"{mol_idx}_{target}.yaml")
+        with open(yaml_path, "w") as f:
+            f.write(yaml_content)
+
+        predict(
+            data=input_dir,
+            out_dir=output_dir,
+            recycling_steps=config['recycling_steps'],
+            sampling_steps=config['sampling_steps'],
+            diffusion_samples=config['diffusion_samples'],
+            sampling_steps_affinity=config['sampling_steps_affinity'],
+            diffusion_samples_affinity=config['diffusion_samples_affinity'],
+            output_format=config['output_format'],
+            seed=mol_idx,
+            affinity_mw_correction=config['affinity_mw_correction'],
+            override=True,
+            num_workers=0,
+        )
+
+        results_path = os.path.join(
+            output_dir, 'boltz_results_inputs', 'predictions', f'{mol_idx}_{target}'
+        )
+        combined_data = {}
+        if os.path.exists(results_path):
+            for filepath in os.listdir(results_path):
+                file_path = os.path.join(results_path, filepath)
+                if filepath.startswith('affinity') or filepath.startswith('confidence'):
+                    try:
+                        with open(file_path, 'r') as f:
+                            data = json.load(f)
+                        combined_data.update(data)
+                    except (json.JSONDecodeError, IOError):
+                        pass
+
+        result_queue.put(("SUCCESS", (smiles, target, combined_data)))
+    except Exception as exc:
+        import traceback as _tb
+        result_queue.put(("ERROR", (smiles, target, f"{exc}\n{_tb.format_exc()}")))
+    finally:
+        if 'tmp_dir' in locals():
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        result_queue.close()
+        result_queue.join_thread()
+
 
 class BoltzWrapper:
     def __init__(self):
@@ -112,25 +199,11 @@ properties:
 
         self._preprocess_data_for_boltz(valid_molecules_by_uid, score_dict)
 
-        # Run Boltz2 for unique molecules
-        bt.logging.info("Running Boltz2")
+        # Run Boltz2 for unique molecules with spawn-process isolation
+        bt.logging.info("Running Boltz2 with per-molecule spawn isolation")
         try:
-            predict(
-                data = self.input_dir,
-                out_dir = self.output_dir,
-                recycling_steps = self.config['recycling_steps'],
-                sampling_steps = self.config['sampling_steps'],
-                diffusion_samples = self.config['diffusion_samples'],
-                sampling_steps_affinity = self.config['sampling_steps_affinity'],
-                diffusion_samples_affinity = self.config['diffusion_samples_affinity'],
-                output_format = self.config['output_format'],
-                seed = self.base_seed,  
-                affinity_mw_correction = self.config['affinity_mw_correction'],
-                override = self.config['override'],
-                num_workers = 0,
-            )
+            self._run_isolated_predictions()
             bt.logging.info(f"Boltz2 predictions complete")
-
         except Exception as e:
             bt.logging.error(f"Error running Boltz2: {e}")
             bt.logging.error(traceback.format_exc())
@@ -139,6 +212,113 @@ properties:
         # Collect scores and distribute results to all UIDs
         self._postprocess_data(score_dict)
         # Defer cleanup tp preserve unique_molecules for result submission
+
+    def _run_isolated_predictions(self) -> None:
+        """Run each molecule-target pair in isolation.
+
+        If already inside a spawn worker (e.g. inference.infer_worker), run
+        sequentially in the current process. Otherwise spawn separate processes
+        for full CUDA isolation.
+        """
+        import torch
+
+        gpu_ids = list(range(torch.cuda.device_count())) or [0]
+        tasks = []
+        for smiles, id_list in self.unique_molecules.items():
+            mol_idx = id_list[0][1]
+            for target in self.subnet_config['small_molecule_target']:
+                clip_interval = (
+                    self.subnet_config['small_molecule_target_clip_interval'][
+                        self.subnet_config['small_molecule_target'].index(target)
+                    ]
+                    if 'small_molecule_target_clip_interval' in self.subnet_config
+                    else None
+                )
+                protein_sequence = get_sequence_from_protein_code(target, clip_interval)
+                tasks.append((smiles, target, protein_sequence, mol_idx))
+
+        if not tasks:
+            return
+
+        # Detect if we are already inside a spawn worker (e.g. inference.infer_worker)
+        # In that case, avoid nested multiprocessing and run sequentially.
+        parent_process = mp.parent_process()
+        if parent_process is not None:
+            bt.logging.info(
+                f"Running {len(tasks)} predictions sequentially inside spawn worker "
+                f"(GPU {gpu_ids[0]}, avoid nested multiprocessing)"
+            )
+            self._isolated_results = {}
+            for smiles, target, protein_sequence, mol_idx in tasks:
+                result_queue = mp.Queue()
+                _spawn_predict_worker(
+                    smiles,
+                    target,
+                    protein_sequence,
+                    mol_idx,
+                    self.base_seed,
+                    self.config,
+                    result_queue,
+                    gpu_ids[0],
+                )
+                try:
+                    status, payload = result_queue.get(timeout=_SPAWN_PREDICT_TIMEOUT)
+                    if status == "ERROR":
+                        bt.logging.error(f"Prediction failed for {smiles}/{target}: {payload[2]}")
+                    else:
+                        smiles, target, combined_data = payload
+                        self._isolated_results.setdefault(smiles, {})[target] = combined_data
+                except Exception as exc:
+                    bt.logging.error(f"Result queue error: {exc}")
+            return
+
+        bt.logging.info(f"Spawning {len(tasks)} isolated predictions across {len(gpu_ids)} GPU(s)")
+        ctx = mp.get_context("spawn")
+        result_queue = ctx.Queue()
+        processes = []
+
+        for i, (smiles, target, protein_sequence, mol_idx) in enumerate(tasks):
+            gpu_id = gpu_ids[i % len(gpu_ids)]
+            p = ctx.Process(
+                target=_spawn_predict_worker,
+                args=(
+                    smiles,
+                    target,
+                    protein_sequence,
+                    mol_idx,
+                    self.base_seed,
+                    self.config,
+                    result_queue,
+                    gpu_id,
+                ),
+            )
+            p.start()
+            processes.append(p)
+
+        # Collect results
+        self._isolated_results = {}
+        errors = []
+        for _ in range(len(processes)):
+            try:
+                status, payload = result_queue.get(timeout=_SPAWN_PREDICT_TIMEOUT)
+                if status == "ERROR":
+                    smiles, target, error_msg = payload
+                    bt.logging.error(f"Prediction failed for {smiles}/{target}: {error_msg}")
+                    errors.append(payload)
+                else:
+                    smiles, target, combined_data = payload
+                    self._isolated_results.setdefault(smiles, {})[target] = combined_data
+            except Exception as exc:
+                bt.logging.error(f"Result queue error: {exc}")
+                errors.append(str(exc))
+
+        for p in processes:
+            if p.is_alive():
+                p.terminate()
+            p.join()
+
+        if errors:
+            bt.logging.warning(f"{len(errors)} prediction(s) failed out of {len(tasks)}")
 
     def _postprocess_data(self, score_dict: dict) -> None:
         scores = self._collect_scores()
@@ -222,8 +402,12 @@ properties:
             if mol_idx not in scores:
                 scores[mol_idx] = {}
             for target in self.subnet_config['small_molecule_target']:
-                results_path = os.path.join(self.output_dir, 'boltz_results_inputs', 'predictions', f'{mol_idx}_{target}')
-                scores[mol_idx][target] = self._load_prediction_files(results_path)
+                # Use isolated prediction results if available, fallback to batch output
+                if hasattr(self, '_isolated_results') and smiles in self._isolated_results and target in self._isolated_results[smiles]:
+                    scores[mol_idx][target] = self._isolated_results[smiles][target]
+                else:
+                    results_path = os.path.join(self.output_dir, 'boltz_results_inputs', 'predictions', f'{mol_idx}_{target}')
+                    scores[mol_idx][target] = self._load_prediction_files(results_path)
 
         return scores
 

--- a/external_tools/boltz/boltz_wrapper.py
+++ b/external_tools/boltz/boltz_wrapper.py
@@ -214,11 +214,11 @@ properties:
         # Defer cleanup tp preserve unique_molecules for result submission
 
     def _run_isolated_predictions(self) -> None:
-        """Run each molecule-target pair in isolation.
+        """Run each molecule-target pair in a separate spawn process.
 
-        If already inside a spawn worker (e.g. inference.infer_worker), run
-        sequentially in the current process. Otherwise spawn separate processes
-        for full CUDA isolation.
+        Uses all available GPUs, distributing tasks round-robin.
+        Processes are launched in batches of len(gpu_ids) to avoid
+        concurrent GPU memory contention.
         """
         import torch
 
@@ -240,82 +240,61 @@ properties:
         if not tasks:
             return
 
-        # Detect if we are already inside a spawn worker (e.g. inference.infer_worker)
-        # In that case, avoid nested multiprocessing and run sequentially.
-        parent_process = mp.parent_process()
-        if parent_process is not None:
-            bt.logging.info(
-                f"Running {len(tasks)} predictions sequentially inside spawn worker "
-                f"(GPU {gpu_ids[0]}, avoid nested multiprocessing)"
-            )
-            self._isolated_results = {}
-            for smiles, target, protein_sequence, mol_idx in tasks:
-                result_queue = mp.Queue()
-                _spawn_predict_worker(
-                    smiles,
-                    target,
-                    protein_sequence,
-                    mol_idx,
-                    self.base_seed,
-                    self.config,
-                    result_queue,
-                    gpu_ids[0],
+        # Number of concurrent processes per GPU (tune based on GPU memory)
+        _PROCESSES_PER_GPU = 2
+
+        bt.logging.info(f"Spawning {len(tasks)} isolated predictions across {len(gpu_ids)} GPU(s), "
+                       f"{_PROCESSES_PER_GPU} process(es) per GPU concurrently")
+        ctx = mp.get_context("spawn")
+        self._isolated_results = {}
+        errors = []
+
+        # Process in batches to avoid concurrent GPU memory contention
+        batch_size = len(gpu_ids) * _PROCESSES_PER_GPU
+        for batch_start in range(0, len(tasks), batch_size):
+            batch = tasks[batch_start:batch_start + batch_size]
+            result_queue = ctx.Queue()
+            processes = []
+
+            for i, (smiles, target, protein_sequence, mol_idx) in enumerate(batch):
+                gpu_id = gpu_ids[i % len(gpu_ids)]
+                p = ctx.Process(
+                    target=_spawn_predict_worker,
+                    args=(
+                        smiles,
+                        target,
+                        protein_sequence,
+                        mol_idx,
+                        self.base_seed,
+                        self.config,
+                        result_queue,
+                        gpu_id,
+                    ),
                 )
+                p.start()
+                processes.append(p)
+
+            # Collect results for this batch
+            for _ in range(len(processes)):
                 try:
                     status, payload = result_queue.get(timeout=_SPAWN_PREDICT_TIMEOUT)
                     if status == "ERROR":
-                        bt.logging.error(f"Prediction failed for {smiles}/{target}: {payload[2]}")
+                        smiles, target, error_msg = payload
+                        bt.logging.error(f"Prediction failed for {smiles}/{target}: {error_msg}")
+                        errors.append(payload)
                     else:
                         smiles, target, combined_data = payload
                         self._isolated_results.setdefault(smiles, {})[target] = combined_data
                 except Exception as exc:
                     bt.logging.error(f"Result queue error: {exc}")
-            return
+                    errors.append(str(exc))
 
-        bt.logging.info(f"Spawning {len(tasks)} isolated predictions across {len(gpu_ids)} GPU(s)")
-        ctx = mp.get_context("spawn")
-        result_queue = ctx.Queue()
-        processes = []
+            for p in processes:
+                if p.is_alive():
+                    p.terminate()
+                p.join()
 
-        for i, (smiles, target, protein_sequence, mol_idx) in enumerate(tasks):
-            gpu_id = gpu_ids[i % len(gpu_ids)]
-            p = ctx.Process(
-                target=_spawn_predict_worker,
-                args=(
-                    smiles,
-                    target,
-                    protein_sequence,
-                    mol_idx,
-                    self.base_seed,
-                    self.config,
-                    result_queue,
-                    gpu_id,
-                ),
-            )
-            p.start()
-            processes.append(p)
-
-        # Collect results
-        self._isolated_results = {}
-        errors = []
-        for _ in range(len(processes)):
-            try:
-                status, payload = result_queue.get(timeout=_SPAWN_PREDICT_TIMEOUT)
-                if status == "ERROR":
-                    smiles, target, error_msg = payload
-                    bt.logging.error(f"Prediction failed for {smiles}/{target}: {error_msg}")
-                    errors.append(payload)
-                else:
-                    smiles, target, combined_data = payload
-                    self._isolated_results.setdefault(smiles, {})[target] = combined_data
-            except Exception as exc:
-                bt.logging.error(f"Result queue error: {exc}")
-                errors.append(str(exc))
-
-        for p in processes:
-            if p.is_alive():
-                p.terminate()
-            p.join()
+            bt.logging.info(f"Batch {batch_start // batch_size + 1}/{(len(tasks) + batch_size - 1) // batch_size} complete")
 
         if errors:
             bt.logging.warning(f"{len(errors)} prediction(s) failed out of {len(tasks)}")

--- a/neurons/validator/setup.py
+++ b/neurons/validator/setup.py
@@ -22,6 +22,8 @@ def get_config():
     
     parser.add_argument('--test_mode', action='store_true', 
                        help='Run test validator without setting weights')
+    parser.add_argument('--immediate_mode', action='store_true',
+                       help='Run test validator without setting weights, but immediately and do not wait epoch boundary')
     parser.add_argument('--local_input_file', type=str, default=None, 
                        help='Path to local input file, enables local mode (doesnt get data from chain)')
 

--- a/neurons/validator/validator.py
+++ b/neurons/validator/validator.py
@@ -270,14 +270,15 @@ async def main(config):
     Main validator loop
     """
     test_mode = bool(getattr(config, 'test_mode', False))
+    immediate_mode = bool(getattr(config, 'immediate_mode', False))
     local_input = bool(getattr(config, 'local_input_file', None))
     
     # Initialize subtensor client
     subtensor = await connect_subtensor(config.network)
     
-    # Wallet + registration check (skipped in test mode)
+    # Wallet + registration check (skipped in test mode or immediate mode)
     wallet = None
-    if test_mode:
+    if test_mode or immediate_mode:
         bt.logging.info("TEST MODE: running without setting weights")
     else:
         try:
@@ -312,6 +313,11 @@ async def main(config):
                 lambda st: st.get_current_block(),
             )
 
+            # In immediate_mode, align to previous epoch boundary and score once
+            if immediate_mode:
+                current_block = (current_block // config.epoch_length) * config.epoch_length
+                bt.logging.info(f"IMMEDIATE_MODE: scoring epoch ending at block {current_block}")
+
             # Only wait for epoch boundary if not reading from local input
             if local_input or current_block % config.epoch_length == 0:
                 # Epoch end - process and set weights
@@ -325,7 +331,7 @@ async def main(config):
                     winner_molecules, winner_nanobodies, uid_to_data = epoch_result
 
                 current_epoch = (current_block // config.epoch_length) - 1
-                if not test_mode:
+                if not test_mode and not immediate_mode:
                     payouts = await set_weights(winner_molecules, winner_nanobodies, config)
                     if payouts:
                         try:
@@ -349,8 +355,8 @@ async def main(config):
                             bt.logging.error(f"Error dispatching bounty payouts: {e}")
                             bt.logging.error(traceback.format_exc())
                 
-                # If using local input, exit after processing
-                if local_input:
+                # Exit after one epoch in immediate_mode or local input mode
+                if immediate_mode or local_input:
                     break
                 
             else:

--- a/utils/inference.py
+++ b/utils/inference.py
@@ -44,8 +44,9 @@ class InferenceResult(NamedTuple):
     boltzgen: BoltzgenResult | None
 
 
-def infer_worker(gpu_id: int, payload: dict, inference_type: str) -> dict:
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+def infer_worker(boltzgen_gpu_id: int | None, payload: dict, inference_type: str) -> dict:
+    if inference_type == "boltzgen" and boltzgen_gpu_id is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(boltzgen_gpu_id)
 
     if inference_type == "boltz":
         from external_tools.boltz.boltz_wrapper import BoltzWrapper
@@ -56,7 +57,7 @@ def infer_worker(gpu_id: int, payload: dict, inference_type: str) -> dict:
             for uid in payload["score_dict"]
         }
         return {
-            "gpu": gpu_id,
+            "gpu": boltzgen_gpu_id,
             "ok": True,
             "boltz": score_dict_updates,
             "per_molecule_components": getattr(boltz, "per_molecule_components", {}),
@@ -70,12 +71,12 @@ def infer_worker(gpu_id: int, payload: dict, inference_type: str) -> dict:
             payload["nanobodies"], payload["config"]
         )
         return {
-            "gpu": gpu_id,
+            "gpu": boltzgen_gpu_id,
             "ok": True,
             "per_nanobody_components": per_nanobody_components,
         }
     else:
-        return {"gpu": gpu_id, "ok": False, "error": f"unknown inference_type={inference_type}"}
+        return {"gpu": boltzgen_gpu_id, "ok": False, "error": f"unknown inference_type={inference_type}"}
 
 
 def _merge_boltz_into_score_dict(score_dict: dict, boltz_result: dict) -> None:
@@ -120,7 +121,11 @@ def _merge_boltzgen_into_score_dict(
 
 def main(valid_molecules_by_uid: dict, valid_nanobodies_by_uid: dict, score_dict: dict, config) -> InferenceResult:
     """
-    Run Boltz and/or Boltzgen inference, each on its own GPU when available.
+    Run Boltz and/or Boltzgen inference sequentially.
+
+    Boltz runs first (using all GPUs via internal spawn isolation), then
+    boltzgen runs on GPU 0. This avoids GPU contention and nested
+    multiprocessing while maximizing boltz throughput.
 
     Updates ``score_dict['molecule_scores']`` in-place. Nanobody inference fills
     ``per_nanobody_components`` only; ranked ``nanobody_scores`` are applied later
@@ -140,30 +145,19 @@ def main(valid_molecules_by_uid: dict, valid_nanobodies_by_uid: dict, score_dict
     per_nanobody_components = None
     per_molecule_components = None
     unique_molecules = None
-    ctx = mp.get_context("spawn")
 
-    if num_gpus >= 2 and run_boltz and run_boltzgen:
-        with ctx.Pool(processes=2) as pool:
-            r_boltz = pool.apply_async(infer_worker, (0, payload_boltz, "boltz"))
-            r_boltzgen = pool.apply_async(infer_worker, (1, payload_boltzgen, "boltzgen"))
-            out_boltz = r_boltz.get()
-            out_boltzgen = r_boltzgen.get()
-        _merge_boltz_into_score_dict(score_dict, out_boltz)
-        per_molecule_components = out_boltz.get("per_molecule_components") or {}
-        unique_molecules = out_boltz.get("unique_molecules") or {}
-        if out_boltzgen.get("ok"):
-            per_nanobody_components = out_boltzgen.get("per_nanobody_components")
-    else:
-        with ctx.Pool(processes=1) as pool:
-            if run_boltz:
-                out = pool.apply_async(infer_worker, (0, payload_boltz, "boltz")).get()
-                _merge_boltz_into_score_dict(score_dict, out)
-                per_molecule_components = out.get("per_molecule_components") or {}
-                unique_molecules = out.get("unique_molecules") or {}
-            if run_boltzgen:
-                out = pool.apply_async(infer_worker, (0, payload_boltzgen, "boltzgen")).get()
-                if out.get("ok"):
-                    per_nanobody_components = out.get("per_nanobody_components")
+    # Run directly in main process to avoid nested multiprocessing.
+    # Boltz spawn isolation happens inside score_molecules() via _spawn_predict_worker.
+    if run_boltz:
+        out = infer_worker(None, payload_boltz, "boltz")
+        _merge_boltz_into_score_dict(score_dict, out)
+        per_molecule_components = out.get("per_molecule_components") or {}
+        unique_molecules = out.get("unique_molecules") or {}
+
+    if run_boltzgen:
+        out = infer_worker(0, payload_boltzgen, "boltzgen")
+        if out.get("ok"):
+            per_nanobody_components = out.get("per_nanobody_components")
 
     boltz = BoltzResult(per_molecule_components, unique_molecules) if run_boltz else None
     boltzgen = BoltzgenResult(per_nanobody_components or {}, None) if run_boltzgen else None


### PR DESCRIPTION
## Summary
  Stable multi-GPU inference with spawn process isolation for deterministic Boltz2 scoring.

**Solution**

  Replace the nested `mp.Pool` in `inference.py` with sequential execution: BOLTZ first, then BOLTZGEN. Move parallelism inside `boltz_wrapper.py` by spawning one isolated process per molecule-target pair via `mp.get_context("spawn")`.

  Each worker:
  - gets its own temp directory
  - sets `CUDA_VISIBLE_DEVICES` to a round-robin GPU
  - runs `predict()` in complete isolation

  Results are collected through a `mp.Queue` with a 1-hour timeout. Post-processing falls back to isolated results when available. Batch size is capped at `num_gpus × 2` to avoid memory contention.

## Epoch 22802 Scoring Test Report

### Basic Information

| Item | Value |
|------|-------|
| Epoch | 22802 |
| Target Protein | O15379 |
| Total Time | 33 minutes 19 seconds |
| Start | 11:27:48 |
| End | 12:01:07 |

### BOLTZ - Small Molecule Scoring

| Item | Value |
|------|-------|
| Number of GPUs | 4 |
| Processes per GPU | 2 |
| Molecules per batch | 8 |
| Submitted Molecule UIDs | 41 |
| Unique Molecules | 38 (after deduplication) |
| Batches | 5/5 |
| Time | 10 minutes 9 seconds |
| Average per batch | ~121 seconds |

### BOLTZGEN - Nanobody Scoring

| Item | Value |
|------|-------|
| GPU | Single GPU 0 |
| Total Time | 20 minutes 6 seconds |
| - design | 13 minutes 13 seconds |
| - folding | 6 minutes 20 seconds |
| - analysis | 23 seconds |

### GPU Usage

| Stage | GPUs | Memory | Util |
|-------|------|--------|------|
| Boltz | 4 parallel (spawn isolation) | ~5-7GB/GPU | 30-40% |
| Boltzgen | 1 (GPU 0) | ~4-6GB | 15-25% |

## Epoch 22804 Scoring Test Report (official main branch)

### Basic Information

| Item | Value |
|------|-------|
| Epoch | 22804 |
| Target Protein | O15379 |
| Total Time | 33 minutes 41 seconds |
| Start | 13:18:04 |
| End | 13:51:45 |

### VALIDITY CHECK

| Item | Time |
|------|------|
| Molecule validity | 0m4s |
| Nanobody validity | 3m25s |

### BOLTZ - Small Molecule Scoring

| Item | Value |
|------|-------|
| Number of GPUs | 1 (single GPU 0) |
| Mode | batch mode (original method) |
| Effective Molecules | 40 |
| Time | 18 minutes 23 seconds |
| Time Range | 13:22:21 → 13:40:44 |

### BOLTZGEN - Nanobody Scoring

| Item | Value |
|------|-------|
| GPU | Single GPU 0 |
| Time Range | 13:22:16 → 13:51:45 |
| - design | 18 minutes 40 seconds |
| - folding | 8 minutes 45 seconds |
| - analysis | 1 minute 53 seconds |

> **Important Note**: BOLTZ and BOLTZGEN run **in parallel** on GPU 0, overlapping by approximately 18 minutes. Total time is not the sum of both, but the later of the two end times.

## Comparison Results

| Item | main | fix/minimal-spawn-isolation |
|------|------|----------------------------|
| Epoch | 22804 | 22802 |
| Effective Molecules | 40 | 38 |
| Effective Nanobodies | 40 | 28 |
| BOLTZ | 18m23s | 10m09s |
| BOLTZGEN design | 18m40s | 13m13s |
| BOLTZGEN folding | 8m45s | 6m20s |
| BOLTZGEN analysis | 1m53s | 0m23s |
| **Total Scoring Time** | **33m41s** | **33m19s** |

> **Note**: On main branch, BOLTZ and BOLTZGEN run in parallel on GPU 0; on fix/minimal-spawn-isolation branch, BOLTZ uses 4 GPUs with spawn isolation parallelism, BOLTZGEN uses GPU 0 serially